### PR TITLE
Fixing separator

### DIFF
--- a/django_unique_slugify.py
+++ b/django_unique_slugify.py
@@ -40,7 +40,7 @@ def unique_slugify(instance, value, slug_field_name='slug', queryset=None,
     next = 2
     while not slug or queryset.filter(**{slug_field_name: slug}):
         slug = original_slug
-        end = '-%s' % next
+        end = '%s%s' % (slug_separator, next)
         if slug_len and len(slug) + len(end) > slug_len:
             slug = slug[:slug_len-len(end)]
             slug = _slug_strip(slug, slug_separator)


### PR DESCRIPTION
Assuming separator is '-' causes problems
What will happen is if my original slug is 'test', slugs will be
`test`
`test-2` after edit renamed to `test_2`,
`test_2-2` after edit renamed to `test_2_2`
`test_2_2-2`...

This should fix it